### PR TITLE
Fix sub menu toggle color when hover other parent menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -71,7 +71,8 @@
 	padding: 18px 50px;
 }
 
-.primary-navigation .menu-wrapper .menu-item-has-children:hover > .sub-menu-toggle{
+.primary-navigation .menu-wrapper .menu-item-has-children > a:hover + .sub-menu-toggle,
+.primary-navigation .menu-wrapper .menu-item-has-children > a:focus + .sub-menu-toggle {
 	color: white;
 }
 

--- a/style.css
+++ b/style.css
@@ -71,7 +71,7 @@
 	padding: 18px 50px;
 }
 
-.primary-navigation > div > .menu-wrapper:hover .sub-menu-toggle{
+.primary-navigation .menu-wrapper .menu-item-has-children:hover > .sub-menu-toggle{
 	color: white;
 }
 


### PR DESCRIPTION
Before: 
![fix-plus-sign-on-parent-menu-when-hover-other-menu-before](https://user-images.githubusercontent.com/1859092/131686569-2fdd9a65-3ae3-49f0-9a18-299d4aaf9d79.gif)

After:
![fix-plus-sign-on-parent-menu-when-hover-other-menu-after2](https://user-images.githubusercontent.com/1859092/131687031-026b8a3d-bbf7-48a8-971d-a271ecc23077.gif)

