### PR TITLE
Add footer navigation CSS

### DIFF
--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -36,3 +36,37 @@
 	margin-top: 0;
 	margin-bottom: 0;
 }
+
+.footer-navigation a {
+	
+  text-decoration: none;
+	
+	span {
+		display: block;
+    text-align: left;
+    text-decoration: underline;
+    text-underline-offset: 1px;
+    font-weight: var(--heading--font-weight-strong);   
+	}
+	
+	&:hover {
+		
+    text-decoration: none !important;
+    
+		span {
+
+		}
+		
+	}
+	
+	.link-label {
+    display: block;
+		line-height: 1;
+    margin-top: -7px;
+    font-weight: var(--heading--font-weight);
+    font-size: 85%;
+    text-decoration: underline;
+    text-decoration-color: #fff;
+	}
+	
+}

--- a/style.css
+++ b/style.css
@@ -272,6 +272,29 @@ html {
   margin-bottom: 0;
 }
 
+.footer-navigation a {
+  text-decoration: none;
+}
+.footer-navigation a span {
+  display: block;
+  text-align: left;
+  text-decoration: underline;
+  text-underline-offset: 1px;
+  font-weight: var(--heading--font-weight-strong);
+}
+.footer-navigation a:hover {
+  text-decoration: none !important;
+}
+.footer-navigation a .link-label {
+  display: block;
+  line-height: 1;
+  margin-top: -7px;
+  font-weight: var(--heading--font-weight);
+  font-size: 85%;
+  text-decoration: underline;
+  text-decoration-color: #fff;
+}
+
 .mt-0 {
   margin-top: 0;
 }


### PR DESCRIPTION
This style addition is according to the footer navigation design: 

![Screen Shot 2021-09-03 at 07 56 49](https://user-images.githubusercontent.com/1859092/131934560-8a01a839-b912-4188-a899-7706b00f3299.png)


Use `small.link-label` tag to insert additional label into the menu's **Navigation Label**. For example: 

```
<small class="link-label">Apr 24, 2016</small>
```

![Screen Shot 2021-09-03 at 07 51 57](https://user-images.githubusercontent.com/1859092/131934472-7e9f91dc-49ca-4dca-84bb-88686790a37a.png)
