### PR TITLE
CSS when cookies not set

### DIFF
--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -36,3 +36,37 @@
 	margin-top: 0;
 	margin-bottom: 0;
 }
+
+.footer-navigation a {
+	
+  text-decoration: none;
+	
+	span {
+		display: block;
+    text-align: left;
+    text-decoration: underline;
+    text-underline-offset: 1px;
+    font-weight: var(--heading--font-weight-strong);   
+	}
+	
+	&:hover {
+		
+    text-decoration: none !important;
+    
+		span {
+
+		}
+		
+	}
+	
+	.link-label {
+    display: block;
+		line-height: 1;
+    margin-top: -7px;
+    font-weight: var(--heading--font-weight);
+    font-size: 85%;
+    text-decoration: underline;
+    text-decoration-color: #fff;
+	}
+	
+}

--- a/scss/_utilities.scss
+++ b/scss/_utilities.scss
@@ -39,3 +39,21 @@
 		text-align: left;
 	}
 }
+
+body.cookies-not-set {
+  
+  .site-footer {
+
+    padding-bottom: 86px;
+
+    @media only screen and (max-width: 978px) {
+      padding-bottom: 106px;
+    }
+
+    @media only screen and (max-width: 540px) {
+      padding-bottom: 130px;
+    }
+    
+  }
+  
+}

--- a/style.css
+++ b/style.css
@@ -340,3 +340,19 @@ html {
     text-align: left;
   }
 }
+
+body.cookies-not-set .site-footer {
+  padding-bottom: 86px;
+}
+
+@media only screen and (max-width: 978px) {
+  body.cookies-not-set .site-footer {
+    padding-bottom: 106px;
+  }
+}
+
+@media only screen and (max-width: 540px) {
+  body.cookies-not-set .site-footer {
+    padding-bottom: 130px;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -272,6 +272,29 @@ html {
   margin-bottom: 0;
 }
 
+.footer-navigation a {
+  text-decoration: none;
+}
+.footer-navigation a span {
+  display: block;
+  text-align: left;
+  text-decoration: underline;
+  text-underline-offset: 1px;
+  font-weight: var(--heading--font-weight-strong);
+}
+.footer-navigation a:hover {
+  text-decoration: none !important;
+}
+.footer-navigation a .link-label {
+  display: block;
+  line-height: 1;
+  margin-top: -7px;
+  font-weight: var(--heading--font-weight);
+  font-size: 85%;
+  text-decoration: underline;
+  text-decoration-color: #fff;
+}
+
 .mt-0 {
   margin-top: 0;
 }


### PR DESCRIPTION
Currently the cookie consent bar is overlaying the footer navigation and credits areas by default when screen is showing the most bottom of the page. This CSS addition fixes it. 

Before: 

![Screen Shot 2021-09-03 at 10 23 44](https://user-images.githubusercontent.com/1859092/131946796-a2e550fa-d201-4a87-a04e-6cabdca7103b.png)

After: 

![Screen Shot 2021-09-03 at 10 27 02](https://user-images.githubusercontent.com/1859092/131947002-33787dc8-bc72-4441-9aca-a4ba819b38e4.png)

