### PR TITLE
Fix spacing issue on footer nav items

### DIFF
--- a/scss/_footer.scss
+++ b/scss/_footer.scss
@@ -40,6 +40,7 @@
 .footer-navigation a {
 	
   text-decoration: none;
+	display: inline-block;
 	
 	span {
 		display: block;

--- a/style.css
+++ b/style.css
@@ -274,6 +274,7 @@ html {
 
 .footer-navigation a {
   text-decoration: none;
+  display: inline-block;
 }
 .footer-navigation a span {
   display: block;


### PR DESCRIPTION
Before: 
![Screen Shot 2021-09-03 at 15 03 41](https://user-images.githubusercontent.com/1859092/131972706-3af9df22-aa1e-4ddf-af55-a83760e44a92.png)

After:
![Screen Shot 2021-09-03 at 15 03 23](https://user-images.githubusercontent.com/1859092/131972735-51be9538-7d42-4734-b796-6a1a8a274420.png)

Seems likely this spacing issue occurs after [this PR](https://github.com/wppolyglots/wptranslationday-6-web-assets/pull/10) been merged.