### PR TITLE
Add smaller font size on page title on mobile screen

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -67,3 +67,12 @@
 		--responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 720px);
 	}
 }
+
+/** 
+ * Page title font size on smaller screen
+ */ 
+@media only screen and (max-width: 760px) {
+	:root {
+		--global--font-size-page-title: var(--global--font-size-xl);
+	}
+}

--- a/style.css
+++ b/style.css
@@ -67,6 +67,14 @@
     --responsive--aligndefault-width: min(calc(100vw - 8 * var(--global--spacing-horizontal)), 720px);
   }
 }
+/** 
+ * Page title font size on smaller screen
+ */ 
+@media only screen and (max-width: 760px) {
+	:root {
+		--global--font-size-page-title: var(--global--font-size-xl);
+	}
+}
 html {
   overflow-x: hidden;
 }


### PR DESCRIPTION
Added as per yui's feedback on [#polyglots-events](https://wordpress.slack.com/archives/C6B54LYCX/p1630664578027300) Make Slack.