### PR TITLE
Fix 404 blog pagination when category base is set to .

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,3 +15,23 @@ function wptd_enqueue_styles() {
         $theme->get('Version') // this only works if you have Version in the style header
     );
 }
+
+/**
+ * Fix 404 pagination on category archive when category base is set to . under Permalink Settings
+ * Ref: https://wordpress.stackexchange.com/questions/311858/how-to-remove-the-term-category-from-category-pagination/311872#311872
+ */
+function wptd_fix_category_pagination( $query_string = array() ) {
+    if( isset( $query_string['category_name'] ) && isset( $query_string['name'] ) && $query_string['name'] === 'page' && isset( $query_string['page'] ) ) {
+      $paged = trim( $query_string['page'], '/' );
+        if( is_numeric( $paged ) ) {
+          // we are not allowing 'page' as a page or post slug 
+          unset( $query_string['name'] );
+          unset( $query_string['page'] )  ;
+
+          // for a category archive, proper pagination query string  is 'paged'
+          $query_string['paged'] = ( int ) $paged;
+        }
+    }   
+    return $query_string;
+}
+add_filter( 'request', 'wptd_fix_category_pagination' );


### PR DESCRIPTION
This issue was confirmed on WPTD Slack: https://wptranslationday.slack.com/archives/C028MPDG5TP/p1631764713153600 

I did some inspections with my test site and found the root of this issue is related with category base, that is currently set to single dot (.). 

![Screen Shot 2021-09-16 at 19 16 09](https://user-images.githubusercontent.com/1859092/133610721-fe34d9cf-5648-4878-8ca0-21a263188ae8.png)


Note: Testing is required before merging. 